### PR TITLE
fix: handle empty workspace in git-clone task

### DIFF
--- a/tekton/task-git-clone.yaml
+++ b/tekton/task-git-clone.yaml
@@ -31,5 +31,6 @@ spec:
         ROOT="$(workspaces.output.path)"
         cd "$ROOT"
         # Same PVC on a later PipelineRun still has the old tree; git clone … . requires an empty dir.
-        find . -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
+        # Use + instead of \; to avoid failure when directory is empty (find returns 1 when no files match)
+        find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + || true
         git clone --depth 1 --branch "$(params.revision)" "$(params.url)" .


### PR DESCRIPTION
## Summary

This PR fixes the git-clone task failure in the PipelineRun `redhat-screensaver-build-fu950z`.

### Root Cause

The git-clone task was failing with exit code 128 because the `find` command in the script was failing when the workspace was empty:

```sh
find . -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
```

When there are no files in the directory, `find` returns exit code 1, and with `set -e` enabled, the script exits immediately before the `git clone` command runs.

### Fix

Changed the find command to:
1. Use `+` instead of `\;` (more efficient for multiple files)
2. Add `|| true` to ensure the command always succeeds

```sh
find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + || true
```

This ensures the script continues even when the workspace is empty (first run) or has files (subsequent runs on the same PVC).