### PR TITLE
Fix git-clone task to handle empty directory case

### DIFF
--- a/tekton/task-git-clone.yaml
+++ b/tekton/task-git-clone.yaml
@@ -31,5 +31,6 @@ spec:
         ROOT="$(workspaces.output.path)"
         cd "$ROOT"
         # Same PVC on a later PipelineRun still has the old tree; git clone … . requires an empty dir.
-        find . -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
+        # Use || true to handle empty directory case (find returns 1 when no files match)
+        find . -mindepth 1 -maxdepth 1 -exec rm -rf {} \; || true
         git clone --depth 1 --branch "$(params.revision)" "$(params.url)" .


### PR DESCRIPTION
## Summary

This PR fixes the git-clone task failure that occurred during the PipelineRun `redhat-screensaver-build-lf95w9`.

### Root Cause

The git-clone task was failing with exit code 128 because the `find` command in the script:

```bash
find . -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
```

returns exit code 1 when there are no files in the directory (no match). With `set -eu` in the script, this causes the script to exit immediately with a non-zero exit code.

### Fix

Added `|| true` to handle the case where the workspace directory is already empty:

```bash
find . -mindepth 1 -maxdepth 1 -exec rm -rf {} \; || true
```

This ensures the script continues even when there are no files to remove in the workspace.