### PR TITLE
Fix typo: change eexpress to express in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "eexpress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes a typo in `package.json` that caused the Tekton pipeline build to fail.

## Root Cause

The `package.json` had a typo: `"eexpress": "^4.21.0"` instead of `"express": "^4.21.0"`. 

During the container build, `npm ci --omit=dev` failed with:
```
npm error code ENOVERSIONS
npm error No versions available for eexpress
```

## Fix

Changed `eexpress` to `express` in the dependencies section of `package.json`.