### PR TITLE
Fix: Use existing image file and add existence check

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,10 @@ const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
 app.use(express.static(PUBLIC));
 
 app.get("/api/image", (req, res) => {
+  // Check if file exists before sending
+  if (!fs.existsSync(IMAGE_PATH)) {
+    return res.status(404).json({ error: "Image not found" });
+  }
   res.type("image/png");
   res.sendFile(IMAGE_PATH);
 });


### PR DESCRIPTION
## Summary

The pod `redhat-screensaver-5d9b8bcdfd-klqb7` was failing with error:
```
Error: ENOENT: no such file or directory, stat '/app/images/punahattu.png'
```

## Root Cause

Commit `245c7a4` removed the check on whether the hat image actually exists, changing the code to reference `punahattu.png` which doesn't exist in the images directory. This was intentionally done to induce errors during demo.

## Fix

1. Changed the image path back to use `redhat.png` which exists in the images directory
2. Added a file existence check before attempting to send the image, returning a proper 404 error if the image is missing

This ensures the application will work correctly and handle missing images gracefully.