### PR TITLE
Fix typo in package.json: replace non-existent package with express

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "somethingsomethingexpress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The Tekton PipelineRun `redhat-screensaver-build-oadgba` failed during the build step because the `package.json` had a typo in the dependencies.

## Root Cause

The `package.json` contained a dependency on `somethingsomethingexpress` which doesn't exist in the npm registry. This caused the Kaniko build to fail with a 404 error:

```
npm error 404 Not Found - GET https://registry.npmjs.org/somethingsomethingexpress - Not found
npm error 404  'somethingsomethingexpress@^4.21.0' is not in this registry.
```

## Fix

Replaced `somethingsomethingexpress` with `express` in the dependencies section of `package.json`.

This is a minimal fix that addresses the root cause without any unrelated changes.