### PR TITLE
Fix typo: expgfdgress -> express

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "expgfdgress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Root Cause
The build failed because `package.json` contained a typo in the dependencies: `expgfdgress` instead of `express`. The npm registry returned a 404 error because no such package exists.

## Fix
Changed `expgfdgress@^4.21.0` to `express@^4.21.0` in package.json.

This is a minimal fix addressing only the typo that caused the build failure.