### PR TITLE
Fix: Replace typo 'expgfdgress' with 'express' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "expgfdgress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the Tekton PipelineRun failure that occurred during the build step.

### Root Cause
The `package.json` contained a typo in the dependencies: `"expgfdgress": "^4.21.0"` instead of `"express": "^4.21.0"`. This caused the npm install step to fail with a 404 error because `expgfdgress` is not a valid npm package.

### Fix
Changed the dependency from `expgfdgress` to `express` in `package.json`. The server code (`server/index.js`) already correctly uses `require("express")`, so this was simply a typo that was likely introduced for demo purposes (as noted in commit history).

### Testing
After merging this PR, the pipeline should successfully build and push the container image.