### PR TITLE
Fix: Replace non-existent 'exphgfdhress' package with 'express'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "exphgfdhress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The Tekton PipelineRun `redhat-screensaver-build-usrfpv` failed during the build step because the `package.json` contained a non-existent npm package called `exphgfdhress`. 

Looking at the server code (`server/index.js`), it uses `express` for the web server, but the dependency was incorrectly specified as `exphgfdhress` (a typo).

This fix replaces `exphgfdhress` with the correct `express` dependency.

## Root Cause

The npm install step failed with:
```
npm error 404 Not Found - GET https://registry.npmjs.org/exphgfdhress - Not found
npm error 404  'exphgfdhress@^4.21.0' is not in this registry.
```

This caused the Kaniko build to fail with exit code 1.