### PR TITLE
Fix: Use existing 'redhat.png' instead of non-existent 'ghfgjghdh.png'

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "ghfgjghdh.png");
+const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
## Summary
The pod logs showed an error:
```
ENOENT: no such file or directory, stat '/app/images/ghfgjghdh.png'
```

The server was configured to serve a non-existent image file `ghfgjghdh.png`. This fix changes the `IMAGE_PATH` to use `redhat.png`, which exists in the images directory.

## Root Cause
The `server/index.js` had a hardcoded path to `ghfgjghdh.png` which doesn't exist in the images directory. This was likely introduced intentionally for demo purposes (as noted in commit history).