### PR TITLE
fix: remove trailing comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.21.0",
-  },
+    "express": "^4.21.0"
+  }
 }


### PR DESCRIPTION
## Summary

The PipelineRun failed during the build step because the `package.json` file contained a trailing comma, making it invalid JSON. This caused `npm ci` to fail when building the Docker image.

## Root Cause

The `package.json` file had a trailing comma after the `express` dependency:
```json
"dependencies": {
    "express": "^4.21.0",  // <-- trailing comma makes JSON invalid
},
```

This invalid JSON caused the `npm ci --omit=dev` command in the Containerfile to fail with an error.

## Fix

Removed the trailing commas to make the JSON valid:
```json
"dependencies": {
    "express": "^4.21.0"
}
```