### PR TITLE
feature: new button to change image

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.21.0"
+    "express": "^4.21.0",
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,7 @@
   const stage = document.getElementById("stage");
   const img = document.getElementById("floater");
   const status = document.getElementById("status");
+  const changeBtn = document.getElementById("change-image");
 
   let vx = 0;
   let vy = 0;
@@ -75,33 +76,41 @@
     }
   });
 
-  fetch("/api/image")
-    .then(async (res) => {
-      if (!res.ok) {
-        const ct = res.headers.get("content-type") || "";
-        if (ct.includes("application/json")) {
-          const body = await res.json();
-          throw new Error(body.error || res.statusText);
+  function loadImage(url) {
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) {
+          const ct = res.headers.get("content-type") || "";
+          if (ct.includes("application/json")) {
+            const body = await res.json();
+            throw new Error(body.error || res.statusText);
+          }
+          throw new Error(res.statusText || "Request failed");
         }
-        throw new Error(res.statusText || "Request failed");
-      }
-      return res.blob();
-    })
-    .then((blob) => {
-      const url = URL.createObjectURL(blob);
-      img.onload = () => {
-        URL.revokeObjectURL(url);
-        img.classList.add("ready");
-        status.textContent = "";
-        startMotion();
-      };
-      img.onerror = () => {
-        URL.revokeObjectURL(url);
-        status.textContent = "Could not display the image.";
-      };
-      img.src = url;
-    })
-    .catch((err) => {
-      status.textContent = err.message || "Failed to load image.";
-    });
+        return res.blob();
+      })
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        img.onload = () => {
+          URL.revokeObjectURL(url);
+          img.classList.add("ready");
+          status.textContent = "";
+          startMotion();
+        };
+        img.onerror = () => {
+          URL.revokeObjectURL(url);
+          status.textContent = "Could not display the image.";
+        };
+        img.src = url;
+      })
+      .catch((err) => {
+        status.textContent = err.message || "Failed to load image.";
+      });
+  }
+
+  loadImage("/api/image");
+
+  changeBtn.addEventListener("click", () => {
+    loadImage("/api/image/next");
+  });
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <div id="stage" aria-hidden="true">
       <img id="floater" alt="" />
     </div>
+    <button id="change-image" aria-label="Change image">↻</button>
     <div id="status" role="status" aria-live="polite"></div>
     <script src="/app.js"></script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -52,3 +52,31 @@ body {
 #status:empty {
   display: none;
 }
+
+#change-image {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid #333;
+  background: rgba(20, 20, 20, 0.85);
+  color: #ccc;
+  font-size: 1.4rem;
+  cursor: pointer;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+#change-image:hover {
+  background: rgba(40, 40, 40, 0.9);
+  color: #fff;
+}
+
+#change-image:active {
+  background: rgba(60, 60, 60, 0.95);
+}

--- a/server/index.js
+++ b/server/index.js
@@ -6,13 +6,45 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGES_DIR = path.join(ROOT, "images");
+
+let currentImageIndex = 0;
+let imageFiles = [];
+
+function loadImageFiles() {
+  imageFiles = fs.readdirSync(IMAGES_DIR).filter((file) => {
+    return file.endsWith(".png") || file.endsWith(".jpg") || file.endsWith(".jpeg") || file.endsWith(".gif");
+  });
+  if (imageFiles.length === 0) {
+    imageFiles = ["redhat.png"];
+  }
+}
+
+loadImageFiles();
+
+function getCurrentImagePath() {
+  return path.join(IMAGES_DIR, imageFiles[currentImageIndex]);
+}
 
 app.use(express.static(PUBLIC));
 
 app.get("/api/image", (req, res) => {
+  const imagePath = getCurrentImagePath();
   res.type("image/png");
-  res.sendFile(IMAGE_PATH);
+  res.sendFile(imagePath);
+});
+
+app.get("/api/image/next", (req, res) => {
+  currentImageIndex = (currentImageIndex + 1) % imageFiles.length;
+  const imagePath = getCurrentImagePath();
+  const imageBuffer = fs.readFileSync(imagePath);
+  const imageBase64 = imageBuffer.toString("base64");
+  const imageData = Buffer.from(imageBase64, "base64");
+  const imageExt = path.extname(imageFiles[currentImageIndex]).toLowerCase();
+  const contentType = imageExt === ".jpg" || imageExt === ".jpeg" ? "image/jpeg" : "image/png";
+  req.headers["if-none-match"] = "no-cache";
+  res.type(contentType);
+  res.send(imageData);
 });
 
 app.get("*", (req, res) => {


### PR DESCRIPTION
Implements #25 - Add a button to change the image

This PR adds a new button in the top right corner of the screen that allows users to cycle through available images in the images/ directory.

Changes:
- Added a button element in index.html with styling in styles.css
- Updated app.js to handle button click and call the new /api/image/next endpoint
- Updated server/index.js to scan the images/ directory and serve images in rotation

The backend now:
- Scans the images/ directory for available images (png, jpg, jpeg, gif)
- Serves the current image on /api/image
- Cycles to the next image on /api/image/next