### PR TITLE
Fix trailing comma in package.json causing npm ci to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.21.0",
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The PipelineRun `redhat-screensaver-build-nfpsi0` failed during the build step because the `package.json` file contained a trailing comma after the `express` dependency, which is invalid JSON.

### Root Cause

The `package.json` file had:
```json
"dependencies": {
  "express": "^4.21.0",
}
```

The trailing comma after `"express": "^4.21.0",` causes `npm ci` to fail with:
```
npm error JSON.parse Expected double-quoted property name in JSON at position 318 while parsing near "...ress\": \"^4.21.0\",\n  }\n}"
```

### Fix

Removed the trailing comma to make the JSON valid:
```json
"dependencies": {
  "express": "^4.21.0"
}
```