### PR TITLE
Fix: Remove nonexistent npm package dependency causing build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.21.0",
-    "nonexistent-package-xyz": "^1.0.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The PipelineRun `redhat-screensaver-build-8ljvmw` in the `agentic-demo` namespace failed during the build step because the `package.json` contained a reference to a non-existent npm package `nonexistent-package-xyz`.

### Root Cause

The build failed with:
```
npm error 404 Not Found - GET https://registry.npmjs.org/nonexistent-package-xyz - Not found
npm error 404  'nonexistent-package-xyz@^1.0.0' is not in this registry.
```

This caused the Kaniko build to fail when running `npm ci --omit=dev` in the Containerfile.

### Fix

Removed the `nonexistent-package-xyz` dependency from `package.json`. The only remaining dependency is `express` which is a valid npm package.