### PR TITLE
Fix: Remove broken npm package that causes build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.21.0",
-    "nonexistent-broken-package": "^1.0.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The PipelineRun `redhat-screensaver-build-p3wsbq` failed during the build step because the `package.json` contained a dependency on `nonexistent-broken-package`, a package that doesn't exist in the npm registry.

This caused the `npm ci` command in the Containerfile to fail with exit code 1.

## Fix

Removed the broken `nonexistent-broken-package` dependency from `package.json`. The only remaining dependency is `express`, which is a valid package that can be installed.