### PR TITLE
Fix: Remove non-existent package dependency that breaks the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "express": "^4.21.0",
-    "nonexistent-package-xyz": "^1.0.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the PipelineRun failure in the `agentic-demo` namespace by removing a non-existent npm package dependency that was causing the Kaniko build to fail.

## Root Cause

The `package.json` contained a dependency on `nonexistent-package-xyz@^1.0.0` which doesn't exist in the npm registry. During the build, `npm ci --omit=dev` failed with a 404 error:

```
npm error 404 Not Found - GET https://registry.npmjs.org/nonexistent-package-xyz - Not found
npm error 404  'nonexistent-package-xyz@^1.0.0' is not in this registry.
```

## Fix

Removed the `nonexistent-package-xyz` dependency from `package.json`, keeping only the valid `express` dependency.