### PR TITLE
Fix: Remove undefinedVariable reference causing ReferenceError

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -34,10 +34,6 @@ app.post("/api/switch", (req, res) => {
   const imageFile = images[currentImageIndex];
   const IMAGE_PATH = path.join(IMAGES_DIR, imageFile);
   
-  // Bug: Try to access a method of an undefined variable
-  // This will cause an error when the button is pressed
-  undefinedVariable.someMethod();
-  
   res.json({ success: true, image: imageFile });
 });
 


### PR DESCRIPTION
## Summary

Fixes the `ReferenceError: undefinedVariable is not defined` error occurring in the pod `redhat-screensaver-84d65b46cc-w76cg`.

### Root Cause
The `/api/switch` endpoint in `server/index.js` contained an intentional bug introduced in PR #39:
```javascript
// Bug: Try to access a method of an undefined variable
// This will cause an error when the button is pressed
undefinedVariable.someMethod();
```

This was described as intentional for demo purposes ("removed the check on whether the hat image actually exists to induce errors during demo").

### Fix
Removed the `undefinedVariable.someMethod()` call and the associated bug comment from the `/api/switch` endpoint.

### Client-Facing Paths
No HTTP routes or API paths were changed. The `/api/switch` endpoint remains at the same path and continues to function correctly.