### PR TITLE
Change floating image from redhat.png to shadowman.png

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
Fixes #42

Changes the floating image in the screensaver from `redhat.png` to `shadowman.png` by updating the `IMAGE_PATH` constant in `server/index.js`.