### PR TITLE
Use shadowman.png instead of redhat.png as the floating image

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
## Summary

This PR updates the server to use `shadowman.png` instead of `redhat.png` as the floating image that bounces around the screen.

### Changes Made

- Modified `server/index.js` to change the `IMAGE_PATH` constant from `"redhat.png"` to `"shadowman.png"`

This change addresses issue #44, which requested using the alternative image (`images/shadowman.png`) as the picture that floats around the screen.