### PR TITLE
Change the screensaver image from redhat.png to shadowman.png

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
## Summary

Changed the screensaver image from `redhat.png` to `shadowman.png` as requested in issue #56.

## Changes Made

- Updated `server/index.js`: Changed `IMAGE_PATH` from `path.join(ROOT, "images", "redhat.png")` to `path.join(ROOT, "images", "shadowman.png")`

The API endpoint `/api/image` will now serve the `shadowman.png` image.

Fixes #56