### PR TITLE
Make the screensaver animation twice as fast (fixes #57)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -8,7 +8,7 @@
   let x = 0;
   let y = 0;
   let rafId = 0;
-  const speed = 6;
+  const speed = 12;
 
   function pickVelocity() {
     const angleMin = 0.698;


### PR DESCRIPTION
Fixes #57

Changed the speed constant in `public/app.js` from 6 to 12, which doubles the velocity at which the image bounces around the viewport, making the screensaver animation twice as fast.