### PR TITLE
Fix package.json: replace invalid dependency expdfhdhfress with express

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "expdfhdhfress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the PipelineRun failure that occurred during the build step.

### Root Cause

The `package.json` file contained an invalid npm dependency `expdfhdhfress` which doesn't exist in the npm registry. This caused the `npm ci --omit=dev` command in the Containerfile to fail with a 404 error.

### Fix

Replaced the invalid dependency `expdfhdhfress` with the correct dependency `express`, which is the package actually used by the server code in `server/index.js`.

### Testing

The fix can be verified by running the PipelineRun again - the build-and-push task should now complete successfully.