### PR TITLE
Fix TypeError in /api/image endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,8 +11,6 @@ const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 app.use(express.static(PUBLIC));
 
 app.get("/api/image", (req, res) => {
-  var breaker = undefined;
-  breaker.methodThatDoesntExists();
   res.type("image/png");
   res.sendFile(IMAGE_PATH);
 });


### PR DESCRIPTION
Fixes #0

This PR fixes a TypeError in the `/api/image` endpoint. The original code contained:

```javascript
var breaker = undefined;
breaker.methodThatDoesntExists();
```

This code was calling a method on `undefined`, which would throw a TypeError whenever the `/api/image` endpoint was accessed. The fix removes this broken code, allowing the image endpoint to work correctly.