### PR TITLE
Fix: Replace fake npm package with express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "exprhjkgfdhgjkldfjkless": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The PipelineRun `redhat-screensaver-build-ujxoo0` in the `agentic-demo` namespace was failing because the `package.json` contained a fake/non-existent npm package name `exprhjkgfdhgjkldfjkless` instead of the real `express` dependency that the server code uses.

This caused the Kaniko build step to fail with:
```
npm error 404 Not Found - GET https://registry.npmjs.org/exprhjkgfdhgjkldfjkless - Not found
```

This fix replaces the fake package with the correct `express` dependency.