### PR TITLE
Fix package.json: replace fake dependency with express

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "expregfdgdfgfdhghjdfgsdgss": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The Tekton PipelineRun `redhat-screensaver-build-f1okpd` failed during the build step because the `package.json` contained a fake/non-existent npm package `expregfdgdfgfdhghjdfgsdgss` instead of the required `express` dependency.

### Root Cause

The build failed with:
```
npm error 404 Not Found - GET https://registry.npmjs.org/expregfdgdfgfdhghjdfgsdgss - Not found
npm error 404  'expregfdgdfgdfgfdhghjdfgsdgss@^4.21.0' is not in this registry.
```

The server code (`server/index.js`) requires `express`:
```javascript
const express = require("express");
```

But the `package.json` had an invalid dependency name `expregfdgdfgfdhghjdfgsdgss` which doesn't exist in the npm registry.

### Fix

Changed the dependency from `expregfdgdfgfdhghjdfgsdgss` to `express` in `package.json`.