### PR TITLE
Fix typo in package.json: exhhgfhfgpress -> express

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "exhhgfhfgpress": "^4.21.0"
+    "express": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary

The PipelineRun `redhat-screensaver-build-2wwqju` failed during the build step because `package.json` contained a typo in the dependency name.

## Root Cause

The `package.json` file had `"exhhgfhfgpress": "^4.21.0"` instead of `"express": "^4.21.0"`. When the Kaniko build process ran `npm ci --omit=dev` in the Containerfile, it failed with:

```
npm error 404 Not Found - GET https://registry.npmjs.org/exhhgfhfgpress - Not found
npm error 404  'exhhgfhfgpress@^4.21.0' is not in this registry.
```

## Fix

Fixed the typo in `package.json` to use the correct package name `express`.