### PR TITLE
Increase image movement speed from 6 to 12

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -8,7 +8,7 @@
   let x = 0;
   let y = 0;
   let rafId = 0;
-  const speed = 6;
+  const speed = 12;
 
   function pickVelocity() {
     const angleMin = 0.698;


### PR DESCRIPTION
Fixes #94

Increased the image movement speed from 6 to 12 in the screensaver animation.