### PR TITLE
Change backend image to shadowman.png

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
## Summary
This PR changes the backend image from `redhat.png` to `shadowman.png` by updating the `IMAGE_PATH` constant in `server/index.js`.

## Changes
- Updated `IMAGE_PATH` in `server/index.js` to point to `images/shadowman.png`

## Acceptance Criteria
- ✅ The `/api/image` endpoint returns `shadowman.png` with correct `Content-Type: image/png`
- ✅ The frontend displays the shadowman image in the screensaver animation

## Related Issue
Fixes #97