### PR TITLE
Change backend image from redhat.png to shadowman.png

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
## Summary
This PR changes the backend image from `redhat.png` to `shadowman.png` as requested in issue #103.

### Changes Made
- Updated `server/index.js`: Changed the `IMAGE_PATH` constant from `redhat.png` to `shadowman.png`

### Verification
- The `images/shadowman.png` file already exists in the repository, so no additional file creation is needed.

Fixes #103