### PR TITLE
Change backend image server to shadowman.png

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const ROOT = path.join(__dirname, "..");
 const PUBLIC = path.join(ROOT, "public");
-const IMAGE_PATH = path.join(ROOT, "images", "redhat.png");
+const IMAGE_PATH = path.join(ROOT, "images", "shadowman.png");
 
 app.use(express.static(PUBLIC));
 


### PR DESCRIPTION
## Summary

This PR changes the backend image server to serve `shadowman.png` instead of `redhat.png`.

### Changes
- Updated `IMAGE_PATH` constant in `server/index.js` (line 8) from `redhat.png` to `shadowman.png`

### Verification
- The `images/shadowman.png` file already exists in the repository

Fixes #107